### PR TITLE
Fix processed varlev population for pressure variable anomalies.

### DIFF
--- a/data/processing.py
+++ b/data/processing.py
@@ -509,12 +509,13 @@ class CDSPreprocessor(object):
         stop = min(start + batch_samples, past_times + n_sample + t_offset)
         return slice(start, stop)
 
-    surface_vars = cds.get_surface_vars(variables)
     var_lev = get_varlev_pairs(variables, levels)
     # Fill in the data. Iterate by variable and level for scaling.
     for vl_index, (vl_var, vl_level) in enumerate(list(zip(variables, levels))):
-      ds_vl = self.raw_ds[vl_var] if vl_var in surface_vars else self.raw_ds[
-          vl_var].sel(level=vl_level)
+      if 'level' not in self.raw_ds[vl_var].coords:
+        ds_vl = self.raw_ds[vl_var]
+      else:
+        ds_vl = self.raw_ds[vl_var].sel(level=vl_level)
       if self.verbose:
         logging.info('Processing variable/level pair %s of %s (%s) in %s.',
                      vl_index + 1, len(var_lev), var_lev[vl_index],


### PR DESCRIPTION
Fixes the variable population process for climatological anomalies of ERA5 pressure variables.

Issue prior to this PR:

- The `pressure_variable_names` dictionary in `cds_era5` was used to determine whether a variable to be added to the processed netCDF was a pressure or surface variable. This works well for all original variables from ERA5, but not for climatological anomalies obtained through functions in  `cds_era5`. In that case, all variables are appended `_anom`, and thus no pressure variable anomaly met the requirement to be considered a pressure variable.

Solution:

- Check whether the DataArray is a pressure variable by checking whether it contains the `level`coordinate. The solution has been successfully tested locally.